### PR TITLE
fix for Schema imports with N level of nesting.

### DIFF
--- a/spec/fixtures/wsdl/operating_unit/Address.xsd
+++ b/spec/fixtures/wsdl/operating_unit/Address.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://schemas.example.co.uk/cdm/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.example.co.uk/cdm/v1" elementFormDefault="qualified">
+	<xsd:element name="AddressDetails" type="tns:AddressDetailsType"/>
+	<xsd:complexType name="AddressDetailsType">
+		<xsd:sequence>
+			<xsd:element name="AddressDetail" type="tns:AddressDetailType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="AddressDetail" type="tns:AddressDetailType"/>
+	<xsd:complexType name="AddressDetailType">
+					<xsd:attribute name="xxx" type="xsd:string"/> 
+		<xsd:sequence>
+			<xsd:element name="AddressLine1" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="AddressLine2" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="Town" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="County" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="Postcode" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="Country2AlphaCode" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>This is in ISO 3166-1 alpha-2, e.g. GB for the UK</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="GeoLatitude" type="xsd:decimal" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="GeoLongitude" type="xsd:decimal" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="ServiceCentreOpUnitCode" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>                        
+			<xsd:element name="RequestBy" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="LocationID" type="xsd:integer" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="Cleansed3rdPartyAddressId" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="PAFAddressKey" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="PAFAddressOrganisaton" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="PAFDeliveryPoint" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/spec/fixtures/wsdl/operating_unit/Contact.xsd
+++ b/spec/fixtures/wsdl/operating_unit/Contact.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://schemas.example.co.uk/cdm/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.example.co.uk/cdm/v1" elementFormDefault="qualified">
+	<xsd:element name="ContactDetails" type="tns:ContactDetailsType"/>
+	<xsd:complexType name="ContactDetailsType">
+		<xsd:sequence>
+			<xsd:element name="ContactDetail" type="tns:ContactDetailType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="ContactDetail" type="tns:ContactDetailType"/>
+	<xsd:complexType name="ContactDetailType">
+		<xsd:sequence>
+			<xsd:element name="Forename" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="Surname" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="Title" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="JobTitle" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="Telephone" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="Mobile" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="HomeTelephone" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="Email" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="OrganisationName" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+			<xsd:element name="DepartmentName" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/spec/fixtures/wsdl/operating_unit/Message.xsd
+++ b/spec/fixtures/wsdl/operating_unit/Message.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://schemas.example.co.uk/cdm/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.example.co.uk/cdm/v1" elementFormDefault="qualified" version="0.1">
+	<xsd:annotation>
+		<xsd:documentation>
+      Canonical message model for all Yodel services's messages 
+      Enables message metadata to be exchanged that will be used for things such as auditing
+    </xsd:documentation>
+	</xsd:annotation>
+	<xsd:element name="Header" type="tns:CanonicalHeaderType"/>
+	<xsd:complexType name="ObjectInstanceInfoType">
+		<xsd:sequence>
+			<xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CanonicalHeaderType">
+		<xsd:sequence>
+			<xsd:element name="MessageID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="Object" type="tns:ObjectInstanceInfoType" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/spec/fixtures/wsdl/operating_unit/OperatingUnit.wsdl
+++ b/spec/fixtures/wsdl/operating_unit/OperatingUnit.wsdl
@@ -1,0 +1,120 @@
+<wsdl:definitions name="RetrieveParcelEventRef" 
+                  targetNamespace="http://services.example.co.uk/fulfilment/pres/v1/operatingunit" 
+                  xmlns:tns="http://services.example.co.uk/fulfilment/pres/v1/operatingunit" 
+                  xmlns:types="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit" 
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+     
+    <wsdl:types>
+        <xsd:schema>
+            <xsd:import namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit" schemaLocation="OperatingUnit.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="GetOpUnitRequestMessage">
+        <wsdl:part name="GetOpUnitRequest" element="types:GetOpUnitRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOpUnitResponseMessage">
+        <wsdl:part name="GetOpUnitResponse" element="types:GetOpUnitResponse"/>
+    </wsdl:message>
+    <wsdl:message name="SearchRequestMessage">
+        <wsdl:part name="SearchRequest" element="types:SearchRequest"/>
+    </wsdl:message>
+    <wsdl:message name="SearchResponseMessage">
+        <wsdl:part name="SearchResponse" element="types:SearchResponse"/>
+    </wsdl:message>
+    <wsdl:message name="UpsertOpUnitRequestMessage">
+        <wsdl:part name="UpsertOpUnitRequest" element="types:UpsertOpUnitRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UpsertOpUnitResponseMessage">
+        <wsdl:part name="UpsertOpUnitResponse" element="types:UpsertOpUnitResponse"/>
+    </wsdl:message>
+    <wsdl:message name="GetOpUnitCalendarRequestMessage">
+        <wsdl:part name="GetOpUnitCalendarRequest" element="types:GetOpUnitCalendarRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOpUnitCalendarResponseMessage">
+        <wsdl:part name="GetOpUnitCalendarResponse" element="types:GetOpUnitCalendarResponse"/>
+    </wsdl:message>
+    <wsdl:message name="UpsertOpUnitCalendarRequestMessage">
+        <wsdl:part name="UpsertOpUnitCalendarRequest" element="types:UpsertOpUnitCalendarRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UpsertOpUnitCalendarResponseMessage">
+        <wsdl:part name="UpsertOpUnitCalendarResponse" element="types:UpsertOpUnitCalendarResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="process_ptt">
+        <wsdl:operation name="getOpUnit">
+            <wsdl:input message="tns:GetOpUnitRequestMessage"/>
+            <wsdl:output message="tns:GetOpUnitResponseMessage"/>
+        </wsdl:operation>
+        <wsdl:operation name="search">
+            <wsdl:input message="tns:SearchRequestMessage"/>
+            <wsdl:output message="tns:SearchResponseMessage"/>
+        </wsdl:operation>
+        <wsdl:operation name="upsertOpUnit">
+            <wsdl:input message="tns:UpsertOpUnitRequestMessage"/>
+            <wsdl:output message="tns:UpsertOpUnitResponseMessage"/>
+        </wsdl:operation>
+        <wsdl:operation name="getOpUnitCalendar">
+            <wsdl:input message="tns:GetOpUnitCalendarRequestMessage"/>
+            <wsdl:output message="tns:GetOpUnitCalendarResponseMessage"/>
+        </wsdl:operation>
+        <wsdl:operation name="upsertOpUnitCalendar">
+            <wsdl:input message="tns:UpsertOpUnitCalendarRequestMessage"/>
+            <wsdl:output message="tns:UpsertOpUnitCalendarResponseMessage"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="process_binding" type="tns:process_ptt">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="getOpUnit">
+            <soap:operation style="document" soapAction="http://services.example.co.uk/fulfilment/pres/v1/operatingunit#getOpUnit"/>
+            <wsdl:input>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="search">
+            <soap:operation style="document" soapAction="http://services.example.co.uk/fulfilment/pres/v1/operatingunit#search"/>
+            <wsdl:input>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="upsertOpUnit">
+            <soap:operation style="document" soapAction="http://services.example.co.uk/fulfilment/pres/v1/operatingunit#upsertOpUnit"/>
+            <wsdl:input>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getOpUnitCalendar">
+            <soap:operation style="document" soapAction="http://services.example.co.uk/fulfilment/pres/v1/operatingunit#getOpUnitCalendar"/>
+            <wsdl:input>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="upsertOpUnitCalendar">
+            <soap:operation style="document" soapAction="http://services.example.co.uk/fulfilment/pres/v1/operatingunit#upsertOpUnitCalendar"/>
+            <wsdl:input>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" namespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="OperatingUnitBindingQSService">
+        <wsdl:documentation>OSB Service</wsdl:documentation>
+        <wsdl:port binding="wsdl:process_binding" name="OperatingUnitBindingQSPort">
+            <soap:address location="http://example.com/some/route/to/services"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/spec/fixtures/wsdl/operating_unit/OperatingUnit.xsd
+++ b/spec/fixtures/wsdl/operating_unit/OperatingUnit.xsd
@@ -1,0 +1,110 @@
+<xsd:schema targetNamespace="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"
+            elementFormDefault="qualified" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://schemas.example.co.uk/fulfilment/pres/v1/operatingunit"
+            xmlns:cdm="http://schemas.example.co.uk/cdm/v1"
+            xmlns:common="http://schemas.example.co.uk/osb/common">
+
+  <xsd:import namespace="http://schemas.example.co.uk/osb/common" schemaLocation="common.xsd"/>
+  <xsd:import namespace="http://schemas.example.co.uk/cdm/v1" schemaLocation="Message.xsd"/>
+  <xsd:import namespace="http://schemas.example.co.uk/cdm/v1" schemaLocation="OperatingUnitRef.xsd"/>
+
+  <xsd:element name="GetOpUnitRequest" type="GetOpUnitRequestType"/>
+  <xsd:complexType name="GetOpUnitRequestType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element ref="cdm:OperatingUnitRef"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="GetOpUnitResponse" type="GetOpUnitResponseType"/>
+  <xsd:complexType name="GetOpUnitResponseType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element name="Outcome" type="xsd:string" />
+      <xsd:element name="OutcomeReason" type="xsd:string" />
+      <xsd:element ref="cdm:OperatingUnitRefs" minOccurs="0" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:element name="SearchRequest" type="SearchRequestType"/>
+  <xsd:complexType name="SearchRequestType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element name="SearchCriteria">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="OperatingUnitCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="OperatingUnitTypeCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="OperatingUnitTypeDesc" type="xsd:string" minOccurs="0" />
+            <xsd:element name="OperatingUnitDesc" type="xsd:string" minOccurs="0" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="SearchResponse" type="SearchResponseType"/>
+  <xsd:complexType name="SearchResponseType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element name="Outcome" type="xsd:string" />
+      <xsd:element name="OutcomeReason" type="xsd:string" />
+      <xsd:element ref="cdm:OperatingUnitRefs" minOccurs="0" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:element name="UpsertOpUnitRequest" type="UpsertOpUnitRequestType"/>
+  <xsd:complexType name="UpsertOpUnitRequestType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element ref="cdm:OperatingUnitRef"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="UpsertOpUnitResponse" type="UpsertOpUnitResponseType"/>
+  <xsd:complexType name="UpsertOpUnitResponseType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element name="Outcome" type="xsd:string" />
+      <xsd:element name="OutcomeReason" type="xsd:string" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:element name="GetOpUnitCalendarRequest" type="GetOpUnitCalendarRequestType"/>
+  <xsd:complexType name="GetOpUnitCalendarRequestType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element name="OperatingUnitCalendar">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="OperatingUnitCode" type="xsd:string" />
+            <xsd:element name="StartDate" type="xsd:date" />
+            <xsd:element name="EndDate" type="xsd:date" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="GetOpUnitCalendarResponse" type="GetOpUnitCalendarResponseType"/>
+  <xsd:complexType name="GetOpUnitCalendarResponseType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element name="Outcome" type="xsd:string" />
+      <xsd:element name="OutcomeReason" type="xsd:string" />
+      <xsd:element ref="cdm:OperatingUnitCalendars" minOccurs="0" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:element name="UpsertOpUnitCalendarRequest" type="UpsertOpUnitCalendarRequestType"/>
+  <xsd:complexType name="UpsertOpUnitCalendarRequestType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element ref="cdm:OperatingUnitRef" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="UpsertOpUnitCalendarResponse" type="UpsertOpUnitCalendarResponseType"/>
+  <xsd:complexType name="UpsertOpUnitCalendarResponseType">
+    <xsd:sequence>
+      <xsd:element ref="cdm:Header"/>
+      <xsd:element name="Outcome" type="xsd:string" />
+      <xsd:element name="OutcomeReason" type="xsd:string" />
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/spec/fixtures/wsdl/operating_unit/OperatingUnitRef.xsd
+++ b/spec/fixtures/wsdl/operating_unit/OperatingUnitRef.xsd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://schemas.example.co.uk/cdm/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://schemas.example.co.uk/cdm/v1" elementFormDefault="qualified">
+  <xsd:include schemaLocation="Address.xsd"/>
+  <xsd:include schemaLocation="Contact.xsd"/>
+  <xsd:include schemaLocation="Message.xsd"/>
+  <xsd:include schemaLocation="OperatingUnitXRef.xsd"/>
+  <xsd:complexType name="OperatingUnitRefsMessage">
+    <xsd:sequence>
+      <xsd:element name="Header" type="tns:CanonicalHeaderType" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="OperatingUnitRefs" type="tns:OperatingUnitRefsType" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="OperatingUnitRefs" type="tns:OperatingUnitRefsType"/>
+  <xsd:complexType name="OperatingUnitRefsType">
+    <xsd:sequence>
+      <xsd:element name="OperatingUnitRef" type="tns:OperatingUnitRefType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="OperatingUnitRef" type="tns:OperatingUnitRefType"/>
+  <xsd:complexType name="OperatingUnitRefType">
+    <xsd:sequence>
+      <xsd:element name="OperatingUnitCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="OperatingUnitTypeCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="OperatingUnitDesc" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="DepotCode" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="RegionCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ParentOperatingUnitCode" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="OperatingUnitAddress" type="tns:AddressDetailType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="OperatingUnitContact" type="tns:ContactDetailType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="MondayOpenTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="MondayCloseTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="TuesdayOpenTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="TuesdayCloseTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="WednesdayOpenTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="WednesdayCloseTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="ThursdayOpenTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="ThursdayCloseTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="FridayOpenTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="FridayCloseTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="SaturdayOpenTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="SaturdayCloseTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="SundayOpenTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="SundayCloseTime" type="xsd:time" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="OperatingUnitTypeRef" type="tns:OperatingUnitTypeRefType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="OperatingUnitCalendars" type="tns:OperatingUnitCalendarsType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="OperatingUnitXRefs" type="tns:OperatingUnitXRefsType" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="OperatingUnitCalendars" type="tns:OperatingUnitCalendarsType"/>
+  <xsd:complexType name="OperatingUnitCalendarsType">
+    <xsd:sequence>
+      <xsd:element name="OperatingUnitCalendar" type="tns:OperatingUnitCalendarType" minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="OperatingUnitCalendar" type="tns:OperatingUnitCalendarType"/>
+  <xsd:complexType name="OperatingUnitCalendarType">
+    <xsd:sequence>
+      <xsd:element name="CalendarDate" type="xsd:date" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="WorkingDayInd" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="OperatingUnitTypeRefs" type="tns:OperatingUnitTypeRefsType"/>
+  <xsd:complexType name="OperatingUnitTypeRefsType">
+    <xsd:sequence>
+      <xsd:element name="OperatingUnitTypeRef" type="tns:OperatingUnitTypeRefType" minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="OperatingUnitTypeRef" type="tns:OperatingUnitTypeRefType"/>
+  <xsd:complexType name="OperatingUnitTypeRefType">
+    <xsd:sequence>
+      <xsd:element name="OperatingUnitTypeCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="OperatingUnitTypeDesc" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="SortCentreInd" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ServiceCentreInd" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="SubServiceCentreInd" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/spec/fixtures/wsdl/operating_unit/OperatingUnitXRef.xsd
+++ b/spec/fixtures/wsdl/operating_unit/OperatingUnitXRef.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://schemas.example.co.uk/cdm/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://schemas.example.co.uk/cdm/v1" elementFormDefault="qualified">
+  <xsd:include schemaLocation="Message.xsd"/>
+  <xsd:complexType name="OperatingUnitXRefsMessage">
+    <xsd:sequence>
+      <xsd:element name="Header" type="tns:CanonicalHeaderType" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="OperatingUnitXRefs" type="tns:OperatingUnitXRefsType" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="OperatingUnitXRefs" type="tns:OperatingUnitXRefsType"/>
+  <xsd:complexType name="OperatingUnitXRefsType">
+    <xsd:sequence>
+      <xsd:element name="OperatingUnitXRef" type="tns:OperatingUnitXRefType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="OperatingUnitXRef" type="tns:OperatingUnitXRefType"/>
+  <xsd:complexType name="OperatingUnitXRefType">
+    <xsd:sequence>
+      <xsd:element name="OperatingUnitCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="XRefCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="XRefDesc" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="XRefTypeCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="DepartmentCode" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+      <xsd:element name="DepartmentDesc" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="OpUnitXRefTypeRef" type="tns:OpUnitXRefTypeRefType"/>
+  <xsd:complexType name="OpUnitXRefTypeRefType">
+    <xsd:sequence>
+      <xsd:element name="XRefTypeCode" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="XRefTypeDesc" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/spec/fixtures/wsdl/operating_unit/common.xsd
+++ b/spec/fixtures/wsdl/operating_unit/common.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="windows-1252" ?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.example.co.uk/osb/common" targetNamespace="http://schemas.example.co.uk/osb/common" elementFormDefault="qualified">
+    <!--<xsd:element name="NameValuePairSet" type="tns:NameValuePairSetType" />
+    <xsd:complexType name="NameValuePairSetType">
+        <xsd:sequence>
+            <xsd:element ref="tns:NameValuePair" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="NameValuePair" type="tns:NameValuePairType"/>
+    <xsd:complexType name="NameValuePairType">
+        <xsd:sequence>
+            <xsd:element name="Name" type="xsd:string"/>
+            <xsd:element name="Value" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>-->
+    
+    <xsd:element name="FaultCodeMappings" type="tns:FaultCodeMappingsType" />
+    <xsd:complexType name="FaultCodeMappingsType">
+        <xsd:sequence>
+            <xsd:element ref="tns:FaultCodeMapping" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="FaultCodeMapping" type="tns:FaultCodeMappingType"/>
+    <xsd:complexType name="FaultCodeMappingType">
+        <xsd:sequence>
+            <xsd:element name="Location" type="xsd:string"/>
+            <xsd:element name="Code" type="xsd:string"/>
+            <xsd:element name="Summary" type="xsd:string"/>
+            <xsd:element name="Detail" type="xsd:string"/>
+            <xsd:element name="Severity">
+              <xsd:simpleType>
+                <xsd:restriction base="xsd:int">
+                  <xsd:enumeration value="1"/>
+                  <xsd:enumeration value="2"/>
+                  <xsd:enumeration value="3"/>
+                  <xsd:enumeration value="4"/>
+                </xsd:restriction>
+              </xsd:simpleType>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+      
+  <xsd:element name="FaultRec" type="tns:FaultRecType"/>
+  <xsd:complexType name="FaultRecType">
+    <xsd:sequence>
+      <xsd:element name="FaultActor" type="xsd:string"/>
+      <xsd:element name="FaultCode" type="xsd:string"/>
+      <xsd:element name="FaultString" type="xsd:string"/>
+      <xsd:element name="FaultTimestamp" type="xsd:dateTime" minOccurs="0"/>
+      <xsd:element name="FaultUniqueID" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="FaultSeverity" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/spec/sekken/wsdl_nested_files_spec.rb
+++ b/spec/sekken/wsdl_nested_files_spec.rb
@@ -22,4 +22,35 @@ describe Sekken::WSDL do
       expect{svc.example_body}.to_not raise_error
     end
   end
+
+  context 'with multiple levels of import' do
+    let(:service) {'OperatingUnitBindingQSService'}
+    let(:binding) {'OperatingUnitBindingQSPort'}
+    let(:client) {Sekken.new fixture('wsdl/operating_unit/OperatingUnit.wsdl')}
+    let(:operations) {["getOpUnit", "search", "upsertOpUnit", "getOpUnitCalendar", "upsertOpUnitCalendar"]}
+    it 'should return list of expected operations' do
+      operation = client.operation(service,binding, "getOpUnit");
+      expect(client.operations(service, binding)).to eq(operations)
+    end
+
+    it 'all operations should return a example body' do
+      client.operations(service, binding).each do |operation|
+        expect(client.operation(service,binding, operation).example_body).to be_a(Hash)
+      end
+    end
+
+    it 'all operations should return a example header' do
+      client.operations(service, binding).each do |operation|
+        expect(client.operation(service,binding, operation).example_header).to be_a(Hash)
+      end
+    end
+
+    it 'should not raise an error when building a request payload' do
+      client.operations(service, binding).each do |operation|
+        op = client.operation(service,binding, operation)
+        op.body = op.example_body
+        expect {op.build}.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi,

I noticed there was an issue when you have more than one level of import. I.E wsdl -> XSD -> XSD. I have changed the `ruby Sekken::Importer#import_schemas` to accommodate this.

Thanks

Andy
